### PR TITLE
Remerge: .NET Standard 2.0 (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,7 +253,7 @@ FakesAssemblies/
 _Pvt_Extensions
 
 # Paket dependency manager
-.paket/paket.exe
+.paket/
 paket-files/
 
 # FAKE - F# Make
@@ -273,3 +273,6 @@ __pycache__/
 # Cake - Uncomment if you are using it
 # tools/**
 # !tools/packages.config
+
+# Visual Studio Code
+.ionide

--- a/Delaunay/Edge.cs
+++ b/Delaunay/Edge.cs
@@ -3,22 +3,16 @@ using System.Numerics;
 
 namespace csDelaunay {
 
-	/*
-	 * The line segment connecting the two Sites is part of the Delaunay triangulation
-	 * The line segment connecting the two Vertices is part of the Voronoi diagram
-	 */
+	/// <summary> The line segment connecting the two Sites is part of the Delaunay triangulation
+	/// The line segment connecting the two Vertices is part of the Voronoi diagram </summary>
 	public class Edge {
 
 		#region Pool
 		private static Queue<Edge> pool = new Queue<Edge>();
 		
 		private static int nEdges = 0;
-		/*
-		 * This is the only way to create a new Edge
-		 * @param site0
-		 * @param site1
-		 * @return
-		 */
+		
+		/// <summary> This is the only way to create a new Edge </summary>
 		public static Edge CreateBisectingEdge(Site s0, Site s1) {
 			float dx, dy;
 			float absdx, absdy;

--- a/README.md
+++ b/README.md
@@ -1,8 +1,24 @@
-csDelaunay
-==========
+# csDelaunay
 
-C# delaunay library
+A .NET library providing Delaunay triangulation and Lloyd relaxation.
 
-This is a port and interpretation of actionscript library [as3delaunay](http://nodename.github.io/as3delaunay/)
+This is a port and interpretation of ActionScript library [as3delaunay](http://nodename.github.io/as3delaunay/).
+- @PouletFrit ported the library from AS3 and added a Lloyd relaxation function.
+- @frabert made significant optimizations.
+- @charlieturndorf provided a cross-platform build (.NET Standard 2) that will also work on .NET Framework.
 
-I also added a Lloyd relaxation function
+### Maintenance Note
+For a maintained fork of csDelaunay, consider using [charlieturndorf/csDelaunay](https://github.com/charlieturndorf/csDelaunay).
+
+## Setup
+1. Clone the repository (you might wish to create a [submodule](https://github.blog/2016-02-01-working-with-submodules/) under another project)
+2. Download and install the [.NET SDK](https://dotnet.microsoft.com/en-us/download), if you don't have it
+3. On the command line, navigate to the root folder of your csDelaunay clone
+4. Run init.cmd to bootstrap the dependency manager
+
+## Build
+1. On the command line, navigate to the root folder of your csDelaunay clone
+2. Run build.cmd
+
+OR
+1. Build with Visual Studio

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,2 @@
+#### 1.0.1.0 - February 27, 2019
+* .NET Standard 2.0 migration

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,1 @@
+dotnet build csDelaunay.sln -c Release

--- a/csDelaunay.csproj
+++ b/csDelaunay.csproj
@@ -1,79 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{8233A279-E59C-4685-9192-4EF9A61B0DE7}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <NoStandardLibraries>false</NoStandardLibraries>
-    <AssemblyName>ClassLibrary</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
-    <RootNamespace>csDelaunay</RootNamespace>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>packages\System.Numerics.Vectors.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Numerics.Vectors.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-    <None Include="README.md" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Delaunay\Edge.cs" />
-    <Compile Include="Delaunay\EdgeList.cs" />
-    <Compile Include="Delaunay\EdgeReorderer.cs" />
-    <Compile Include="Delaunay\Halfedge.cs" />
-    <Compile Include="Delaunay\HalfedgePriorityQueue.cs" />
-    <Compile Include="Delaunay\ICoord.cs" />
-    <Compile Include="Delaunay\LR.cs" />
-    <Compile Include="Delaunay\Site.cs" />
-    <Compile Include="Delaunay\SiteList.cs" />
-    <Compile Include="Delaunay\Triangle.cs" />
-    <Compile Include="Delaunay\Vertex.cs" />
-    <Compile Include="Delaunay\Voronoi.cs" />
-    <Compile Include="Geom\Circle.cs" />
-    <Compile Include="Geom\LineSegment.cs" />
-    <Compile Include="Geom\Polygon.cs" />
-    <Compile Include="Geom\Rectf.cs" />
-    <Compile Include="Geom\Winding.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include=".git\" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSHARP.Targets" />
-  <ProjectExtensions>
-    <VisualStudio AllowExistingFolder="true" />
-  </ProjectExtensions>
+  <Import Project=".paket\Paket.Restore.targets" />
 </Project>

--- a/csDelaunay.sln
+++ b/csDelaunay.sln
@@ -1,9 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2046
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "csDelaunay", "csDelaunay.csproj", "{8233A279-E59C-4685-9192-4EF9A61B0DE7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{335937CA-13F4-4D9D-9B9A-4A884E4C5B0E}"
+	ProjectSection(SolutionItems) = preProject
+		paket.dependencies = paket.dependencies
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,5 +23,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A71A468D-83F1-43EF-852B-EBE9A785355C}
 	EndGlobalSection
 EndGlobal

--- a/directory.build.props
+++ b/directory.build.props
@@ -1,0 +1,10 @@
+<Project>
+  <PropertyGroup>
+    <Version>1.0.1.1</Version>
+    <AssemblyVersion>1.0.1.1</AssemblyVersion>
+    <FileVersion>1.0.1.1</FileVersion>
+    <Authors>PouletFrit, frabert, charlieturndorf</Authors>
+    <Product>csDelaunay</Product>
+    <Copyright>Copyright © PouletFrit 2014 (MIT license)</Copyright>
+  </PropertyGroup>
+</Project>

--- a/init.cmd
+++ b/init.cmd
@@ -1,0 +1,2 @@
+dotnet tool install Paket --tool-path .paket
+.paket\paket restore

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.Numerics.Vectors" version="4.3.0" targetFramework="net45" />
-</packages>

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,0 +1,4 @@
+source https://api.nuget.org/v3/index.json
+framework: >= netstandard2.0
+
+nuget System.Numerics.Vectors ~> 4.5.0

--- a/paket.lock
+++ b/paket.lock
@@ -1,0 +1,4 @@
+RESTRICTION: >= netstandard2.0
+NUGET
+  remote: https://api.nuget.org/v3/index.json
+    System.Numerics.Vectors (4.5)

--- a/paket.references
+++ b/paket.references
@@ -1,0 +1,1 @@
+System.Numerics.Vectors


### PR DESCRIPTION
Merging frabert/csDelaunay#1 back down.

### Highlights
- Migrated to .NET Standard 2.0
   - Build on .NET SDK 2.1.5 or higher

- Updated to System.Numerics.Vectors 4.5

- Added Paket: a dependency manager that separates out concrete dependencies from transitory dependencies, and also provides robust dependency versioning control

- Added build.cmd and init.cmd
  - When you clone csDelaunay, run init.cmd once to bootstrap Paket

- Updated readme
  - Maintenance note for @frabert's parent fork: suggests using @charlieturndorf's maintained fork
  - Setup & build instructions
  - Key contributions